### PR TITLE
Add note about instructions requiring -CURRENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ make
 WARNING: Normal users should use the image that quickstart generates under images.
 To setup a build machine with the correct version of FreeBSD 12-CURRENT, you'll want these install instructions.
 
+Note that these instructions only work if you are already running a `-CURRENT` release. You will need to follow the instructions [here](https://www.freebsd.org/doc/handbook/makeworld.html) to upgrade from `-RELEASE` to `-CURRENT`.
+
 ## Install
 ```
 pkg install git


### PR DESCRIPTION
Instructions fail if you run them on a `-RELEASE` box. Note that, and point at the instructions for upgrading.